### PR TITLE
Update tox to run most environments in Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,9 @@ isolated_build = True
 
 [gh-actions]
 python =
-    3.6: py36, isort, black, lint, types
+    3.6: py36
     3.7: py37
-    3.8: py38
+    3.8: py38, isort, black, lint, types
 
 [testenv]
 deps =
@@ -64,25 +64,25 @@ changedir = {toxinidir}/tests
 commands = python3 -m pytest --cov={envsitepackagesdir}/todo_extractor
 
 [testenv:black]
-basepython = python3.6
+basepython = python3.8
 deps = black
 changedir = {toxinidir}
 commands = black . --diff --check
 
 [testenv:lint]
-basepython = python3.6
+basepython = python3.8
 deps = pylint
 commands = pylint --rcfile={toxinidir}/pylintrc {envsitepackagesdir}/todo_extractor
 
 [testenv:types]
-basepython = python3.6
+basepython = python3.8
 deps = mypy
 commands = python3 -m mypy {toxinidir}/todo_extractor
 
 [testenv:isort]
-basepython = python3.6
+basepython = python3.8
 deps = isort[pyproject]
-commands = isort -rc {toxinidir}/todo_extractor
+commands = isort --recursive --check {toxinidir}/todo_extractor
 """
 
 [tool.black]


### PR DESCRIPTION
The previous setup where they was run in 3.6 was based on that it
was the lowest version that was supported and if something would
work in that version it would (most probably) work in higher as
well. But on the other hand that it was the tests coverage is for,
so it does not make sense to run black et al. in a different version
than the latest.

Isorts -rc flag is apparently only recursive, not a combination of
recursive and check, so the flags was listed more explicitly.